### PR TITLE
Fix config utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@ Information management system for PCEA St. Andrew's Church school
 
 [![Continuous Integration](https://github.com/pcea-st-andrews/church-school/actions/workflows/ci.yml/badge.svg)](https://github.com/pcea-st-andrews/church-school/actions/workflows/ci.yml)
 [![Coverage Status](https://coveralls.io/repos/github/pcea-st-andrews/church-school/badge.svg?branch=main)](https://coveralls.io/github/pcea-st-andrews/church-school?branch=main)
-
+[![Documentation Status](https://readthedocs.org/projects/church-school-ims/badge/?version=latest)](https://church-school-ims.readthedocs.io/en/latest/?badge=latest)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,5 +1,6 @@
 import re
 
+
 def list_of_tuples(string):
     names = [s.strip("'") for s in re.findall(r"'\w+'", string)]
     emails = re.findall(r"\w+@\w+.\w+", string)

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,2 +1,6 @@
-def list_of_tuples(str):
-    return list(eval(str))
+import re
+
+def list_of_tuples(string):
+    names = [s.strip("'") for s in re.findall(r"'\w+'", string)]
+    emails = re.findall(r"\w+@\w+.\w+", string)
+    return list(zip(names, emails))

--- a/utils/tests/test_config.py
+++ b/utils/tests/test_config.py
@@ -5,9 +5,6 @@ import utils.config
 
 class ConfigUtilsTestCase(unittest.TestCase):
     def test_list_of_tuples(self):
-        with self.assertRaises(TypeError):
-            utils.config.list_of_tuples()
-
         admins = [("Admin", "admin@example.com"), ("Manager", "manager@example.com")]
         self.assertListEqual(admins, utils.config.list_of_tuples(str(admins)))
 


### PR DESCRIPTION
- Extract the names and emails in `ADMIN` via regex instead of passing them to `eval`
- Rename the arg in `list_of_tuples` from `str` to `string`
- Remove the function call without arguments in tests